### PR TITLE
Fix for Error when creating new folder.

### DIFF
--- a/Get-EventSession.ps1
+++ b/Get-EventSession.ps1
@@ -1084,7 +1084,7 @@ param(
         Write-Host "Using download path: $DownloadFolder"
         # Create the local content path if not exists
         if ( (Test-Path $DownloadFolder) -eq $false ) {
-            New-Item -LiteralPath $DownloadFolder -ItemType Directory | Out-Null
+            New-Item -Path $DownloadFolder -ItemType Directory | Out-Null
         }
 
         If ( $NoVideos) {


### PR DESCRIPTION
Fix for New-Item LiteralPath
New-Item doesn't support the "LiteralPath" parameter, should use "Path" instead.
![image](https://user-images.githubusercontent.com/8736291/196680528-140e2e55-cfd4-4298-9125-799b87574db0.png)

